### PR TITLE
RVM-772: query by username

### DIFF
--- a/log_manager_cli/openfin_log_cli.py
+++ b/log_manager_cli/openfin_log_cli.py
@@ -87,7 +87,7 @@ def get_logs(args):
     start_date, end_date = set_dates(args)
     query_params = {"startDate": start_date, "endDate": end_date}
     if args.username:
-        query_params['username'] = args.username
+        query_params['userName'] = args.username
 
     suffix_url = 'Applications/' + args.app_name
     url = urljoin(user_config.base_url, suffix_url)

--- a/log_manager_cli/openfin_log_cli.py
+++ b/log_manager_cli/openfin_log_cli.py
@@ -86,6 +86,9 @@ def get_logs(args):
 
     start_date, end_date = set_dates(args)
     query_params = {"startDate": start_date, "endDate": end_date}
+    if args.username:
+        query_params['username'] = args.username
+
     suffix_url = 'Applications/' + args.app_name
     url = urljoin(user_config.base_url, suffix_url)
 
@@ -189,6 +192,7 @@ def main():
     parser.add_argument("--download-log", help="download log with given uuid")
     parser.add_argument("--version", action="store_true", help="Shows the version")
     parser.add_argument("--configure", action="store_true", help="Configure the CLI")
+    parser.add_argument("--username", help="Sets a username used for seeing app logs")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Added a --username command line arg. The get_log function now checks for that argument and adds it to the query_params, if it is set.

Example:
```
$ python openfin_log_cli.py --app-name="someApp" --get-logs --username="mockUsername"
```